### PR TITLE
Modify backend to sleep if args arent provided (allows frontend dev t…

### DIFF
--- a/limiinal_client/src/backend/network.rs
+++ b/limiinal_client/src/backend/network.rs
@@ -3,6 +3,7 @@ use std::{
     error::Error,
     hash::{Hash, Hasher},
     str::FromStr,
+    thread,
     time::Duration,
 };
 
@@ -82,7 +83,18 @@ impl AppCore {
             .with_env_filter(EnvFilter::from_default_env())
             .try_init();
 
-        let opts = Opts::parse();
+        let opts = loop {
+            // Try parsing the command-line arguments
+            match Opts::try_parse() {
+                Ok(args) => {
+                    break args;
+                }
+
+                Err(err) => {
+                    thread::sleep(Duration::from_secs(120)); // Sleep to avoid busy CPU usage
+                }
+            }
+        };
 
         #[derive(NetworkBehaviour)]
         struct Behaviour {


### PR DESCRIPTION
## **Description**

Modified backend/network.rs so if the program arguments can't be parsed (i.e. they're not provided) then the thread goes into a sleep loop. This allows the program to at least continue running without crashing. Should allow front-end development to continue without interruption.

## **Checklist**

Please ensure your PR meets the following requirements before requesting a review:

- [x] All Rust code is formatted using `cargo fmt`.
- [x] Documentation has been updated as necessary (`README.md`, code comments, etc.).
- [x] Changes have been tested manually.

## **Testing Instructions**

1. **Steps to test this PR**:
 
```
cd limiinal_client
cargo run
```


2. **Expected results**:
   GUI will launch and backend thread will show a panick but gui continues to work.

## **Types of Changes**

- [ ] Bugfix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (please describe): Temp fix for dev purposes.

## **Reviewer Notes**

Backend thread does panic but this will be resolved shortly.

---

Thank you for contributing to the Limiinal! 🎉
