### PR TITLE
Added an argument '--backend-enable' that if not present, prevents ba…

### DIFF
--- a/limiinal_client/src/backend/network.rs
+++ b/limiinal_client/src/backend/network.rs
@@ -39,6 +39,9 @@ struct Opts {
     /// Peer ID of the remote peer to hole punch to.
     #[clap(long)]
     remote_peer_id: Option<PeerId>,
+
+    #[clap(long, action = clap::ArgAction::SetTrue)]
+    backend_enable: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Parser)]

--- a/limiinal_client/src/ui/gui.rs
+++ b/limiinal_client/src/ui/gui.rs
@@ -2,6 +2,7 @@
 
 use crate::backend::network::AppCore;
 
+use clap::{Arg, Command};
 use iced::border::Radius;
 use iced::keyboard;
 use iced::widget;
@@ -14,6 +15,7 @@ use iced::widget::{button, center, column, container, image, row, svg, text, tex
 use iced::widget::{button::Status, Column, Space};
 use iced::{Alignment, Background, Border, Color, Element, Length, Padding, Task, Theme};
 use log::info;
+use std::env;
 
 macro_rules! asset_path {
     ($path:expr) => {
@@ -54,14 +56,28 @@ pub enum Message {
 
 impl AppUI {
     pub fn new() -> (Self, Task<Message>) {
+        let mut tasks = vec![];
+
+        let args: Vec<String> = env::args().skip(1).collect();
+        let mut backend_enable = false;
+
+        for arg in &args {
+            if arg == "--backend-enable" {
+                backend_enable = true;
+            }
+        }
+
+        if backend_enable {
+            tasks.push(Task::perform(AppCore::run(), |_| Message::RunningBackend));
+        }
+
+        tasks.push(widget::focus_next());
+
         (
             Self {
                 ..Default::default()
             },
-            Task::batch([
-                Task::perform(AppCore::run(), |_| Message::RunningBackend),
-                widget::focus_next(),
-            ]),
+            Task::batch(tasks),
         )
     }
 


### PR DESCRIPTION
## **Description**

Added an argument '--backend-enable' that if not present, prevents backend from running. This is checked by using sys args in the gui thread before the backend task is launched, if flag isn't present then the backend task never starts.

## **Checklist**

Please ensure your PR meets the following requirements before requesting a review:

- [x] All Rust code is formatted using `cargo fmt`.
- [x] Documentation has been updated as necessary (`README.md`, code comments, etc.).
- [x] Changes have been tested manually.

## **Testing Instructions**

1. **Steps to test this PR**:

Run the client

2. **Expected results**:
   - If no arguments are provided the gui will launch and backend won't run
   - If only the argument "--backend-enable" is provided you will get a usage error. e.g:

```
  error: the following required arguments were not provided:
  --mode <MODE>
  --secret-key-seed <SECRET_KEY_SEED>
  --relay-address <RELAY_ADDRESS>

Usage: limiinal_client --mode <MODE> --secret-key-seed <SECRET_KEY_SEED> --relay-address <RELAY_ADDRESS> --backend-enable
```
  - If all arguments are provided the backend will panic but gui will continue :)




## **Types of Changes**

- [ ] Bugfix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [x] Other (please describe): Temp dev feature

## **Reviewer Notes**

Addressed  the previous issue where the args weren't being checked if they were present, this implementation does not modify existing checks.

---

Thank you for contributing to the Limiinal! 🎉
